### PR TITLE
Update agent to track events from ExoPlayer 2.17.0

### DIFF
--- a/NRExoPlayerTracker/build.gradle
+++ b/NRExoPlayerTracker/build.gradle
@@ -3,13 +3,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
-        versionName "0.99.1"
+        versionName "0.99.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -40,7 +40,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.2.1'
     implementation project(path: ':NewRelicVideoCore')
-    implementation 'com.google.android.exoplayer:exoplayer:+'
+    implementation 'com.google.android.exoplayer:exoplayer:2.17.0'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/NRIMATracker/build.gradle
+++ b/NRIMATracker/build.gradle
@@ -3,13 +3,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30
         versionCode 1
-        versionName "0.99.0"
+        versionName "0.99.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/NewRelicVideoCore/build.gradle
+++ b/NewRelicVideoCore/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16

--- a/Test/app/build.gradle
+++ b/Test/app/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "com.newrelic.coretest"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,12 +3,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "com.newrelic.nrvideoproject"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 
@@ -26,6 +26,10 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    packagingOptions {
+        exclude("META-INF/*.kotlin_module")
     }
 }
 
@@ -45,7 +49,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
-    implementation 'com.google.android.exoplayer:exoplayer:+'
+    implementation 'com.google.android.exoplayer:exoplayer:2.17.0'
     implementation 'com.google.android.exoplayer:extension-ima:+'
 
     implementation 'com.newrelic.agent.android:android-agent:+'


### PR DESCRIPTION
Since ExoPlayer release 2.17.0, this agent does not compile.

- Replace deprecated methods and interface.
- Target specific ExoPlayer version to avoid unwanted behaviour.
- Bump version to 0.99.6