### PR TITLE
Add pause & resume events for ads and modify state conditions

### DIFF
--- a/NRExoPlayerTracker/build.gradle
+++ b/NRExoPlayerTracker/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 30
         versionCode 1
-        versionName "0.99.7"
+        versionName "0.99.8"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -403,7 +403,7 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
             if (getState().isRequested && !getState().isStarted) {
                 sendStart();
             }
-            else if (getState().isPaused) {
+            else if (getState().isPaused && !player.isPlayingAd()) {
                 sendResume();
             }
             else if (!getState().isRequested && !getState().isStarted) {
@@ -420,7 +420,7 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         else {
             NRLog.d("\tVideo Paused");
 
-            if (getState().isPlaying) {
+            if (getState().isPlaying && !player.isPlayingAd()) {
                 sendPause();
             }
         }

--- a/NRIMATracker/build.gradle
+++ b/NRIMATracker/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 30
         versionCode 1
-        versionName "0.99.7"
+        versionName "0.99.8"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/NRIMATracker/src/main/java/com/newrelic/videoagent/ima/tracker/NRTrackerIMA.java
+++ b/NRIMATracker/src/main/java/com/newrelic/videoagent/ima/tracker/NRTrackerIMA.java
@@ -68,6 +68,12 @@ public class NRTrackerIMA extends NRVideoTracker implements AdErrorEvent.AdError
                 quartile = 3L;
                 sendAdQuartile();
                 break;
+            case PAUSED:
+                sendPause();
+                break;
+            case RESUMED:
+                sendResume();
+                break;
         }
     }
 


### PR DESCRIPTION
On Android, when pressing play/pause on ads, the ExoPlayer event listener was triggering pause and resume events on the content tracker (`NRTrackerExoPlayer`) instead of just triggering them on the ad tracker (`NRTrackerIMA`). 

## 👷 Work Done

* Add `PAUSED` and `RESUMED` ad events.
* Modify player state change conditions to avoid triggering pause and resume events on ads.
* Bump version 0.99.7 to 0.99.8.

## 📓 Reference
This is directly linked to the following PR: https://github.com/mirego/bellmedia-jasper/pull/2720