### PR TITLE
Return null contentSrc when no playlist is set

### DIFF
--- a/NRExoPlayerTracker/build.gradle
+++ b/NRExoPlayerTracker/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 30
         versionCode 1
-        versionName "0.99.8"
+        versionName "0.99.9"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -197,9 +197,9 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         if (player == null) return null;
 
         if (getPlaylist() != null) {
-            NRLog.d("Current window index = " + player.getCurrentWindowIndex());
+            NRLog.d("Current window index = " + player.getCurrentMediaItemIndex());
             try {
-                Uri src = getPlaylist().get(player.getCurrentWindowIndex());
+                Uri src = getPlaylist().get(player.getCurrentMediaItemIndex());
                 return src.toString();
             }
             catch (Exception e) {
@@ -452,9 +452,9 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         NRLog.d("onTracksChanged analytics");
 
         // Next track in the playlist
-        if (player.getCurrentWindowIndex() != lastWindow) {
+        if (player.getCurrentMediaItemIndex() != lastWindow) {
             NRLog.d("Next video in the playlist starts");
-            lastWindow = player.getCurrentWindowIndex();
+            lastWindow = player.getCurrentMediaItemIndex();
             sendRequest();
         }
     }

--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -203,11 +203,11 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
                 return src.toString();
             }
             catch (Exception e) {
-                return "";
+                return null;
             }
         }
         else {
-            return "";
+            return null;
         }
     }
 

--- a/NRIMATracker/build.gradle
+++ b/NRIMATracker/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 30
         versionCode 1
-        versionName "0.99.8"
+        versionName "0.99.9"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
On Android, when no playlists are set, getSrc returns an empty string for the contentSrc attribute, which may cause problems when sending analytics. Also, a deprecated method of the ExoPlayer was used.

## 👷 Work Done

* Return null src url when playlist is null.
* Modify deprecated `getCurrentWindowIndex()` ExoPlayer method for `getCurrentMediaItemIndex()` ([documentation here](https://exoplayer.dev/doc/reference/com/google/android/exoplayer2/Player.html#getCurrentWindowIndex())).
* Bump version 0.99.8 to 0.99.9.