### PR TITLE
Update ExoPlayer2 to AndroidX Media3

### DIFF
--- a/NRExoPlayerTracker/build.gradle
+++ b/NRExoPlayerTracker/build.gradle
@@ -6,7 +6,7 @@ plugins {
 apply from: '../publishing.gradle'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 16
@@ -43,7 +43,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.2.1'
     implementation project(path: ':NewRelicVideoCore')
-    implementation 'com.google.android.exoplayer:exoplayer:2.17.1'
+    implementation 'androidx.media3:media3-exoplayer:1.1.0'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -2,15 +2,15 @@ package com.newrelic.videoagent.exoplayer.tracker;
 
 import android.net.Uri;
 
-import com.google.android.exoplayer2.ExoPlayer;
-import com.google.android.exoplayer2.PlaybackException;
-import com.google.android.exoplayer2.Player;
-import com.google.android.exoplayer2.SimpleExoPlayer;
-import com.google.android.exoplayer2.TracksInfo;
-import com.google.android.exoplayer2.analytics.AnalyticsListener;
-import com.google.android.exoplayer2.source.LoadEventInfo;
-import com.google.android.exoplayer2.source.MediaLoadData;
-import com.google.android.exoplayer2.video.VideoSize;
+import androidx.media3.common.PlaybackException;
+import androidx.media3.common.Player;
+import androidx.media3.common.Tracks;
+import androidx.media3.common.VideoSize;
+import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.analytics.AnalyticsListener;
+import androidx.media3.exoplayer.source.LoadEventInfo;
+import androidx.media3.exoplayer.source.MediaLoadData;
+
 import com.newrelic.videoagent.core.tracker.NRVideoTracker;
 import com.newrelic.videoagent.core.utils.NRLog;
 import com.newrelic.videoagent.exoplayer.BuildConfig;
@@ -448,7 +448,7 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
     }
 
     @Override
-    public void onTracksInfoChanged(EventTime eventTime, TracksInfo tracksInfo) {
+    public void onTracksChanged(EventTime eventTime, Tracks tracks) {
         NRLog.d("onTracksChanged analytics");
 
         // Next track in the playlist

--- a/NRIMATracker/build.gradle
+++ b/NRIMATracker/build.gradle
@@ -6,7 +6,7 @@ plugins {
 apply from: '../publishing.gradle'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 16
@@ -43,7 +43,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.3.0'
     implementation project(path: ':NewRelicVideoCore')
-    implementation 'com.google.android.exoplayer:extension-ima:2.17.1'
+    implementation 'androidx.media3:media3-exoplayer-ima:1.1.0'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/NewRelicVideoCore/build.gradle
+++ b/NewRelicVideoCore/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.1.0'
-    implementation 'com.newrelic.agent.android:android-agent:7.0.0'
+    implementation 'com.newrelic.agent.android:android-agent:+'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/NewRelicVideoCore/build.gradle
+++ b/NewRelicVideoCore/build.gradle
@@ -6,7 +6,7 @@ plugins {
 apply from: '../publishing.gradle'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 16
@@ -42,7 +42,7 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.1.0'
-    implementation 'com.newrelic.agent.android:android-agent:+'
+    implementation 'com.newrelic.agent.android:android-agent:6.9.2'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/NewRelicVideoCore/build.gradle
+++ b/NewRelicVideoCore/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.1.0'
-    implementation 'com.newrelic.agent.android:android-agent:6.9.2'
+    implementation 'com.newrelic.agent.android:android-agent:7.0.0'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/Test/app/build.gradle
+++ b/Test/app/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.newrelic.coretest"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation 'androidx.media3:media3-exoplayer-ima:1.1.0'
     implementation 'androidx.media3:media3-exoplayer-dash:1.1.0'
 
-    implementation 'com.newrelic.agent.android:android-agent:7.0.0'
+    implementation 'com.newrelic.agent.android:android-agent:+'
 
     implementation 'com.android.support:multidex:1.0.3'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.newrelic.nrvideoproject"
@@ -49,10 +49,12 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
-    implementation 'com.google.android.exoplayer:exoplayer:2.17.1'
-    implementation 'com.google.android.exoplayer:extension-ima:2.17.1'
+    implementation 'androidx.media3:media3-exoplayer:1.1.0'
+    implementation 'androidx.media3:media3-ui:1.1.0'
+    implementation 'androidx.media3:media3-exoplayer-ima:1.1.0'
+    implementation 'androidx.media3:media3-exoplayer-dash:1.1.0'
 
-    implementation 'com.newrelic.agent.android:android-agent:+'
+    implementation 'com.newrelic.agent.android:android-agent:6.9.2'
 
     implementation 'com.android.support:multidex:1.0.3'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation 'androidx.media3:media3-exoplayer-ima:1.1.0'
     implementation 'androidx.media3:media3-exoplayer-dash:1.1.0'
 
-    implementation 'com.newrelic.agent.android:android-agent:6.9.2'
+    implementation 'com.newrelic.agent.android:android-agent:7.0.0'
 
     implementation 'com.android.support:multidex:1.0.3'
 }

--- a/app/src/main/java/com/newrelic/nrvideoproject/VideoPlayer.java
+++ b/app/src/main/java/com/newrelic/nrvideoproject/VideoPlayer.java
@@ -1,11 +1,13 @@
 package com.newrelic.nrvideoproject;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.media3.common.MediaItem;
+import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.SimpleExoPlayer;
+import androidx.media3.ui.PlayerView;
+
 import android.os.Bundle;
 import android.util.Log;
-import com.google.android.exoplayer2.MediaItem;
-import com.google.android.exoplayer2.SimpleExoPlayer;
-import com.google.android.exoplayer2.ui.PlayerView;
 import com.newrelic.videoagent.core.NewRelicVideoAgent;
 import com.newrelic.videoagent.core.tracker.NRVideoTracker;
 import com.newrelic.videoagent.exoplayer.tracker.NRTrackerExoPlayer;
@@ -15,7 +17,7 @@ import java.util.Map;
 
 public class VideoPlayer extends AppCompatActivity {
 
-    private SimpleExoPlayer player;
+    private ExoPlayer player;
     private Integer trackerId;
 
     @Override

--- a/app/src/main/java/com/newrelic/nrvideoproject/VideoPlayerAds.java
+++ b/app/src/main/java/com/newrelic/nrvideoproject/VideoPlayerAds.java
@@ -4,24 +4,26 @@ import android.net.Uri;
 import android.os.Bundle;
 import com.google.ads.interactivemedia.v3.api.AdErrorEvent;
 import com.google.ads.interactivemedia.v3.api.AdEvent;
-import com.google.android.exoplayer2.MediaItem;
-import com.google.android.exoplayer2.SimpleExoPlayer;
-import com.google.android.exoplayer2.ext.ima.ImaAdsLoader;
-import com.google.android.exoplayer2.source.DefaultMediaSourceFactory;
-import com.google.android.exoplayer2.ui.PlayerView;
-import com.google.android.exoplayer2.upstream.DataSource;
-import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
-import com.google.android.exoplayer2.util.Util;
 import com.newrelic.videoagent.core.NewRelicVideoAgent;
 import com.newrelic.videoagent.core.tracker.NRVideoTracker;
 import com.newrelic.videoagent.exoplayer.tracker.NRTrackerExoPlayer;
 import com.newrelic.videoagent.ima.tracker.NRTrackerIMA;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.media3.common.MediaItem;
+import androidx.media3.common.util.Util;
+import androidx.media3.datasource.DataSource;
+import androidx.media3.datasource.DefaultDataSourceFactory;
+import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.SimpleExoPlayer;
+import androidx.media3.exoplayer.ima.ImaAdsLoader;
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
+import androidx.media3.ui.PlayerView;
+
 import android.util.Log;
 
 public class VideoPlayerAds extends AppCompatActivity implements AdErrorEvent.AdErrorListener, AdEvent.AdEventListener {
 
-    private SimpleExoPlayer player;
+    private ExoPlayer player;
     private Integer trackerId;
     private ImaAdsLoader adsLoader;
     private PlayerView playerView;

--- a/app/src/main/res/layout/activity_video_player.xml
+++ b/app/src/main/res/layout/activity_video_player.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     tools:context=".VideoPlayer">
 
-    <com.google.android.exoplayer2.ui.PlayerView
+    <androidx.media3.ui.PlayerView
         android:id="@+id/player"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_video_player_ads.xml
+++ b/app/src/main/res/layout/activity_video_player_ads.xml
@@ -6,7 +6,7 @@ android:layout_width="match_parent"
 android:layout_height="match_parent"
 tools:context=".VideoPlayerAds">
 
-<com.google.android.exoplayer2.ui.PlayerView
+<androidx.media3.ui.PlayerView
     android:id="@+id/player"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.1"
+        classpath 'com.android.tools.build:gradle:7.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip


### PR DESCRIPTION
ExoPlayer2 received it's last update with `2.19.0`.

We now migrate to the new AndroidX Media3 which essentially contains the same code.